### PR TITLE
Remove compression of output files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 # Base R image
 FROM docker.io/rocker/r-ver
 
-RUN apt-get update && apt-get -y install --no-install-recommends zstd 
-
 # Install R dependencies
 RUN Rscript -e "install.packages('pak')"
 RUN Rscript -e "pak::pak(c('dplyr', 'arrow', 'future.apply'))"

--- a/R/generate_test_data.R
+++ b/R/generate_test_data.R
@@ -135,8 +135,3 @@ future.apply::future_lapply(dates, function(i) {
 
   return(i)
 })
-
-
-# Compress
-# Multithreading supplied to zstd with `-T` flag
-system(sprintf("tar -I 'zstd -T%s' -cvf data-output/test_data.tar.zst data-output/test_data", workers))

--- a/R/generate_test_data_2.R
+++ b/R/generate_test_data_2.R
@@ -115,6 +115,3 @@ lapply(dates, function(i){
 
   gc()
 })
-
-# Compress
-system("tar -zcvf data-output/test_data.tar.gz --directory=data-output test_data")

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To create the data in a container using Podman or Docker:
 1. Build the container `podman build --platform linux/amd64 -t demo_data .`
 1. Run the container `podman run --name demo_data demo_data`
    1. To opt into parallel processing, do `podman run --name demo_data -e PARALLEL_WORKERS=n demo_data` where `n` is the number of cores to use
-1. Fetch the sample data from the container with: `podman cp demo_data:data-output/test_data.tar.zst data-output/test_data.tar.zst`
+1. Fetch the sample data from the container with: `podman cp demo_data:data-output/test_data/ data-output/`
 
 > [!CAUTION]
 > When running the container with parallelisation be sensible with the number of workers. The program will crash if you provide more than can be used, surfacing an error starting with `MultisessionFuture (future_lapply-6) failed to receive message results from cluster RichSOCKnode`. If this happens, reduce the number of workers and try again.

--- a/README.md
+++ b/README.md
@@ -20,9 +20,6 @@ To create the data in a container using Podman or Docker:
 1. Run the container `podman run --name demo_data demo_data`
    1. To opt into parallel processing, do `podman run --name demo_data -e PARALLEL_WORKERS=n demo_data` where `n` is the number of cores to use
 1. Fetch the sample data from the container with: `podman cp demo_data:data-output/test_data.tar.zst data-output/test_data.tar.zst`
-1. Decompress the archive and try the examples
-   1. Windows: use WinRAR or 7Zip
-   1. Mac/Linux: install zstd, then `tar -xf data-output/test_data.tar.zst`
 
 > [!CAUTION]
 > When running the container with parallelisation be sensible with the number of workers. The program will crash if you provide more than can be used, surfacing an error starting with `MultisessionFuture (future_lapply-6) failed to receive message results from cluster RichSOCKnode`. If this happens, reduce the number of workers and try again.


### PR DESCRIPTION
Addresses https://github.com/smartdatafoundry/hive_guide/issues/3.

We agreed there was no need to compress output files from the test/example data generation. Accordingly, this PR removes compression and also updates the relevant part of the readme.

I've tested `R/generate_test_data.R` both locally and via the container instructions.